### PR TITLE
Adds a host option.

### DIFF
--- a/PusherServer.Tests/UnitTests/PusherOptions.cs
+++ b/PusherServer.Tests/UnitTests/PusherOptions.cs
@@ -35,5 +35,12 @@ namespace PusherServer.Tests.UnitTests
             options.Encrypted = true;
             Assert.AreEqual(90, options.Port);
         }
+
+        [Test]
+        public void Host_defaults_to_api_pusherapp_com()
+        {
+            var options = new PusherOptions();
+            Assert.AreEqual("api.pusherapp.com", options.Host);
+        }
     }
 }

--- a/PusherServer/IPusherOptions.cs
+++ b/PusherServer/IPusherOptions.cs
@@ -36,5 +36,17 @@ namespace PusherServer
             get;
             set;
         }
+
+        /// <summary>
+        /// Gets or sets the REST API host that the HTTP calls will be made to.
+        /// </summary>
+        /// <value>
+        /// The port.
+        /// </value>
+        string Host
+        {
+            get;
+            set;
+        }
     }
 }

--- a/PusherServer/Pusher.cs
+++ b/PusherServer/Pusher.cs
@@ -13,8 +13,6 @@ namespace PusherServer
     /// </summary>
     public class Pusher : IPusher
     {
-        private static string DEFAULT_REST_API_HOST = "api.pusherapp.com";
-
         private string _appId;
         private string _appKey;
         private string _appSecret;
@@ -310,7 +308,7 @@ namespace PusherServer
         private Uri GetBaseUrl(IPusherOptions _options)
         {
             string baseUrl = (_options.Encrypted ? "https" : "http") + "://" +
-                DEFAULT_REST_API_HOST +
+                _options.Host +
                 (_options.Port == 80 ? "" : ":" + _options.Port);
             return new Uri( baseUrl );
         }

--- a/PusherServer/PusherOptions.cs
+++ b/PusherServer/PusherOptions.cs
@@ -10,11 +10,13 @@ namespace PusherServer
     {
         private static int DEFAULT_HTTPS_PORT = 443;
         private static int DEFAULT_HTTP_PORT = 80;
+        private static string DEFAULT_REST_API_HOST = "api.pusherapp.com";
 
         IRestClient _client;
         bool _encrypted = false;
         bool _portModified = false;
         int _port = DEFAULT_HTTP_PORT;
+        string _host = DEFAULT_REST_API_HOST;
 
         /// <summary>
         /// Gets or sets a value indicating whether calls to the Pusher REST API are over HTTP or HTTPS.
@@ -33,7 +35,7 @@ namespace PusherServer
                 _encrypted = value;
                 if (_encrypted && _portModified == false)
                 {
-                    _port = 443;
+                    _port = DEFAULT_HTTPS_PORT;
                 }
             }
         }
@@ -54,6 +56,24 @@ namespace PusherServer
             {
                 _port = value;
                 _portModified = true;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the REST API host that the HTTP calls will be made to.
+        /// </summary>
+        /// <value>
+        /// The port.
+        /// </value>
+        public string Host
+        {
+            get
+            {
+                return _host;
+            }
+            set
+            {
+                _host = value;
             }
         }
 


### PR DESCRIPTION
I'm doing some tests with [poxa](https://github.com/edgurgel/poxa) and I can't use this lib without this option. 

I also made a small fix in the `PusherOptions.cs`. It wasn't using the `DEFAULT_HTTPS_PORT` constant.

