### PR TITLE
Fixed use of Pusher by multiple threads

### DIFF
--- a/PusherServer.Core/RestfulClient/PusherRestClient.cs
+++ b/PusherServer.Core/RestfulClient/PusherRestClient.cs
@@ -35,6 +35,10 @@ namespace PusherServer.RestfulClient
             _httpClient = new HttpClient { BaseAddress = baseAddress };
             _libraryName = libraryName;
             _version = version.ToString(3);
+            _httpClient.DefaultRequestHeaders.Clear();
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _httpClient.DefaultRequestHeaders.Add("Pusher-Library-Name", _libraryName);
+            _httpClient.DefaultRequestHeaders.Add("Pusher-Library-Version", _version);
         }
 
         ///<inheritDoc/>
@@ -45,10 +49,6 @@ namespace PusherServer.RestfulClient
         ///<inheritDoc/>
         public async Task<GetResult<T>> ExecuteGetAsync<T>(IPusherRestRequest pusherRestRequest)
         {
-            _httpClient.DefaultRequestHeaders.Clear();
-            _httpClient.DefaultRequestHeaders.Add("Pusher-Library-Name", _libraryName);
-            _httpClient.DefaultRequestHeaders.Add("Pusher-Library-Version", _version);
-
             if (pusherRestRequest.Method == PusherMethod.GET)
             {
                 var response = await _httpClient.GetAsync(pusherRestRequest.ResourceUri);
@@ -63,11 +63,6 @@ namespace PusherServer.RestfulClient
         ///<inheritDoc/>
         public async Task<TriggerResult> ExecutePostAsync(IPusherRestRequest pusherRestRequest)
         {
-            _httpClient.DefaultRequestHeaders.Clear();
-            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            _httpClient.DefaultRequestHeaders.Add("Pusher-Library-Name", _libraryName);
-            _httpClient.DefaultRequestHeaders.Add("Pusher-Library-Version", _version);
-
             if (pusherRestRequest.Method == PusherMethod.POST)
             {
                 var content = new StringContent(pusherRestRequest.GetContentAsJsonString(), Encoding.UTF8, "application/json");


### PR DESCRIPTION
We noticed this because threads would get stuck accessing the
headers dictionary in the HttpClient class used by Pusher.
This often means that the dictionary has been corrupted by
concurrent access. Our application uses a singleton Pusher instance
which is shared by multiple threads. We're working around it in
our application by using an instance per thread instead of a
shared instance, but since this is a common patter maybe we should
make the client thread-safe?