### PR TITLE
library code should use .ConfigureAwait(false) on every await 

### DIFF
--- a/PusherServer.Core/Pusher.cs
+++ b/PusherServer.Core/Pusher.cs
@@ -77,7 +77,7 @@ namespace PusherServer
         /// <inheritdoc/>
         public async Task<ITriggerResult> TriggerAsync(string channelName, string eventName, object data, ITriggerOptions options = null)
         {
-            return await TriggerAsync(new[] { channelName }, eventName, data, options);
+            return await TriggerAsync(new[] { channelName }, eventName, data, options).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -92,7 +92,7 @@ namespace PusherServer
 
             DebugTriggerRequest(request);
 
-            var result = await _options.RestClient.ExecutePostAsync(request);
+            var result = await _options.RestClient.ExecutePostAsync(request).ConfigureAwait(false);
 
             DebugTriggerResponse(result);
 
@@ -108,7 +108,7 @@ namespace PusherServer
 
             DebugTriggerRequest(request);
 
-            var result = await _options.RestClient.ExecutePostAsync(request);
+            var result = await _options.RestClient.ExecutePostAsync(request).ConfigureAwait(false);
 
             DebugTriggerResponse(result);
 
@@ -175,7 +175,7 @@ namespace PusherServer
         {
             var request = _factory.Build(PusherMethod.GET, resource, parameters);
 
-            var response = await _options.RestClient.ExecuteGetAsync<T>(request);
+            var response = await _options.RestClient.ExecuteGetAsync<T>(request).ConfigureAwait(false);
 
             return response;
         }
@@ -193,7 +193,7 @@ namespace PusherServer
 
             var request = _factory.Build(PusherMethod.GET, string.Format(ChannelUsersResource, channelName));
 
-            var response = await _options.RestClient.ExecuteGetAsync<T>(request);
+            var response = await _options.RestClient.ExecuteGetAsync<T>(request).ConfigureAwait(false);
 
             return response;
         }
@@ -205,7 +205,7 @@ namespace PusherServer
 
             var request = _factory.Build(PusherMethod.GET, string.Format(ChannelResource, channelName), info);
 
-            var response = await _options.RestClient.ExecuteGetAsync<T>(request);
+            var response = await _options.RestClient.ExecuteGetAsync<T>(request).ConfigureAwait(false);
 
             return response;
         }
@@ -215,7 +215,7 @@ namespace PusherServer
         {
             var request = _factory.Build(PusherMethod.GET, MultipleChannelsResource, info);
 
-            var response = await _options.RestClient.ExecuteGetAsync<T>(request);
+            var response = await _options.RestClient.ExecuteGetAsync<T>(request).ConfigureAwait(false);
 
             return response;
         }

--- a/PusherServer.Core/RestfulClient/PusherRestClient.cs
+++ b/PusherServer.Core/RestfulClient/PusherRestClient.cs
@@ -51,8 +51,8 @@ namespace PusherServer.RestfulClient
         {
             if (pusherRestRequest.Method == PusherMethod.GET)
             {
-                var response = await _httpClient.GetAsync(pusherRestRequest.ResourceUri);
-                var responseContent = await response.Content.ReadAsStringAsync();
+                var response = await _httpClient.GetAsync(pusherRestRequest.ResourceUri).ConfigureAwait(false);
+                var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 return new GetResult<T>(response, responseContent);
             }
@@ -67,8 +67,8 @@ namespace PusherServer.RestfulClient
             {
                 var content = new StringContent(pusherRestRequest.GetContentAsJsonString(), Encoding.UTF8, "application/json");
 
-                var response = await _httpClient.PostAsync(pusherRestRequest.ResourceUri, content);
-                var responseContent = await response.Content.ReadAsStringAsync();
+                var response = await _httpClient.PostAsync(pusherRestRequest.ResourceUri, content).ConfigureAwait(false);
+                var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
                 return new TriggerResult(response, responseContent);
             }


### PR DESCRIPTION
so it won't cause a deadlock if called synchronously from outside(in rare cases you do want to call it synchronously)
just add it where needed
more info here:
http://blog.stephencleary.com/2012/07/dont-block-on-async-code.html