### PR TITLE
Exception text use responseContent

### DIFF
--- a/PusherServer.Core/TriggerResult.cs
+++ b/PusherServer.Core/TriggerResult.cs
@@ -27,7 +27,7 @@ namespace PusherServer
             }
             catch (Exception)
             {
-                string msg = $"The response body from the Pusher HTTP endpoint could not be parsed as JSON: {Environment.NewLine}{response.Content}";
+                string msg = $"The response body from the Pusher HTTP endpoint could not be parsed as JSON: {Environment.NewLine}{responseContent}";
                 throw new TriggerResponseException(msg);
             }
 

--- a/PusherServer.Tests/UnitTests/TriggerResult.cs
+++ b/PusherServer.Tests/UnitTests/TriggerResult.cs
@@ -54,14 +54,21 @@ namespace PusherServer.Tests.UnitTests
         }
 
         [Test]
-        [ExpectedException(typeof (TriggerResponseException))]
         public void it_should_treat_non_JSON_content_in_the_request_body_as_a_failed_request()
         {
             HttpResponseMessage response = Substitute.For<HttpResponseMessage>();
             response.Content = new StringContent("FISH");
             response.StatusCode = HttpStatusCode.OK;
 
-            new TriggerResult(response, "FISH");
+            try
+            {
+                new TriggerResult(response, "FISH");
+                Assert.Fail("Exception was not thrown");
+            }
+            catch (TriggerResponseException ex)
+            {
+                Assert.IsTrue(ex.Message.Contains("FISH"), "exception message includes response");
+            }
         }
 
         [Test]

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ within your application as follows.
 For more information see <https://pusher.com/docs/channels/server_api/webhooks>.
 
 ```cs
-// How you get these depends on the framework you're using
+// How you get these depends on the framework you are using
 
 // HTTP_X_PUSHER_SIGNATURE from HTTP Header
 var receivedSignature = "value";


### PR DESCRIPTION
Exception text from TriggerResult should report the string that failed to parse responseContent, not response.content which is an object of type StreamContent. Fixes #56 