### PR TITLE
Add PusherRestClient constructor to accept an externally supplied HttpClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.7.0
+* [ADDED] Constructor for PusherRestClient accepting an externally supplied HttpClient
+
 ## 4.7.0-beta
 * [ADDED] AuthenticateUser
 * [ADDED] AuthorizeChannel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 # Changelog
 
-## 4.6.2
-* [ADDED] Constructor for PusherRestClient accepting an externally supplied HttpClient
-
-## 4.7.0
+## 4.7.0-beta.2
 * [ADDED] Constructor for PusherRestClient accepting an externally supplied HttpClient
 
 ## 4.7.0-beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.6.2
+* [ADDED] Constructor for PusherRestClient accepting an externally supplied HttpClient
+
 ## 4.7.0
 * [ADDED] Constructor for PusherRestClient accepting an externally supplied HttpClient
 

--- a/PusherServer/RestfulClient/PusherRestClient.cs
+++ b/PusherServer/RestfulClient/PusherRestClient.cs
@@ -25,18 +25,32 @@ namespace PusherServer.RestfulClient
         {}
 
         /// <summary>
-        /// Constructs a new instance of the PusherRestClient
+        /// Constructs a new instance of the PusherRestClient with a supplied HttpClient
         /// </summary>
         /// <param name="baseAddress">The base address of the Pusher API</param>
         /// <param name="libraryName">The name of the Pusher Library</param>
         /// <param name="version">The version of the Pusher library</param>
-        public PusherRestClient(Uri baseAddress, string libraryName, Version version)
+        public PusherRestClient(Uri baseAddress, string libraryName, Version version):this(CreateDefaultHttpClient(baseAddress), libraryName, version)
+        {}
+
+        private static HttpClient CreateDefaultHttpClient(Uri baseAddress)
         {
-            _httpClient = new HttpClient 
+            return new HttpClient 
             { 
                 BaseAddress = baseAddress,
                 Timeout = TimeSpan.FromSeconds(30),
             };
+        }
+        
+        /// <summary>
+        /// Constructs a new instance of the PusherRestClient with a supplied HttpClient
+        /// </summary>
+        /// <param name="httpClient">An externally configured HttpClient</param>
+        /// <param name="libraryName">The name of the Pusher Library</param>
+        /// <param name="version">The version of the Pusher library</param>
+        public PusherRestClient(HttpClient httpClient, string libraryName, Version version)
+        {
+            _httpClient = httpClient;
             _libraryName = libraryName;
             _version = version.ToString(3);
             _httpClient.DefaultRequestHeaders.Clear();

--- a/Root.Build.props
+++ b/Root.Build.props
@@ -12,9 +12,9 @@
     <PackageTags>pusher channels realtime websocket</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>icon-128.png</PackageIcon>
-    <Version>4.7.0</Version>
-    <AssemblyVersion>4.7.0.0</AssemblyVersion>
-    <FileVersion>4.7.0.0</FileVersion>
+    <Version>4.6.2</Version>
+    <AssemblyVersion>4.6.2.0</AssemblyVersion>
+    <FileVersion>4.6.2.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Root.Build.props
+++ b/Root.Build.props
@@ -12,7 +12,7 @@
     <PackageTags>pusher channels realtime websocket</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>icon-128.png</PackageIcon>
-    <Version>4.7.0-beta</Version>
+    <Version>4.7.0</Version>
     <AssemblyVersion>4.7.0.0</AssemblyVersion>
     <FileVersion>4.7.0.0</FileVersion>
   </PropertyGroup>

--- a/Root.Build.props
+++ b/Root.Build.props
@@ -12,9 +12,9 @@
     <PackageTags>pusher channels realtime websocket</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>icon-128.png</PackageIcon>
-    <Version>4.6.2</Version>
-    <AssemblyVersion>4.6.2.0</AssemblyVersion>
-    <FileVersion>4.6.2.0</FileVersion>
+    <Version>4.7.0-beta.2</Version>
+    <AssemblyVersion>4.7.0.0</AssemblyVersion>
+    <FileVersion>4.7.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

- Created new constructor for `PusherRestClient` accepting an externally supplied `HttpClient`
- Changed the original `PusherRestClient` constructor to call the new one with a default `HttpClient`
- original [PR](https://github.com/pusher/pusher-http-dotnet/pull/89)

## CHANGELOG

* [ADDED] Constructor for PusherRestClient accepting an externally supplied HttpClient
