### PR TITLE
Major: Add channel attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.0.0
+* [CHANGED] Describe your change here. Look at CHANGELOG.md to see the format.
+
 ## 4.7.0-beta.2
 * [ADDED] Constructor for PusherRestClient accepting an externally supplied HttpClient
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 5.0.0
-* [CHANGED] Describe your change here. Look at CHANGELOG.md to see the format.
+* [ADDED] Add support for channel attributes when triggering events
 
 ## 4.7.0-beta.2
 * [ADDED] Constructor for PusherRestClient accepting an externally supplied HttpClient

--- a/PusherServer.Tests/AcceptanceTests/Trigger.cs
+++ b/PusherServer.Tests/AcceptanceTests/Trigger.cs
@@ -419,6 +419,8 @@ namespace PusherServer.Tests.AcceptanceTests
     [TestFixture]
     public class When_requesting_channel_attributes
     {
+        static Random random = new Random();
+
         [Test]
         public async Task It_should_return_channel_attributes_for_multiple_channels()
         {
@@ -499,13 +501,11 @@ namespace PusherServer.Tests.AcceptanceTests
 
         private static string GetPublicChannelName()
         {
-            var random = new Random();
             return $"test-channel-{random.Next()}";
         }
 
         private static string GetPresenceChannelName()
         {
-            var random = new Random();
             return $"presence-test-channel-{random.Next()}";
         }
     }

--- a/PusherServer.Tests/UnitTests/TriggerResult.cs
+++ b/PusherServer.Tests/UnitTests/TriggerResult.cs
@@ -18,6 +18,17 @@ namespace PusherServer.Tests.UnitTests
                             "}" +
                         "}";
 
+        public static string TRIGGER_RESPONSE_WITH_CHANNEL_ATTRIBUTES = "{" +
+                            "\"channels\": {" +
+                                "\"any-channel\": {" +
+                                    "\"user_count\": 1," +
+                                    "\"subscription_count\": 2" +
+                                "}" +
+                            "}," +
+                            "\"event_ids\": {" +
+                                "\"any-channel\": \"test-id\"" +
+                            "}" +
+                        "}";
     }
 
     [TestFixture]
@@ -84,6 +95,20 @@ namespace PusherServer.Tests.UnitTests
             var triggerResult = new TriggerResult(response, TriggerResultHelper.TRIGGER_RESPONSE_JSON);
 
             triggerResult.EventIds.Add("fish", "pie");
+        }
+
+        [Test]
+        public void it_should_parse_channel_attributes()
+        {
+            HttpResponseMessage response = Substitute.For<HttpResponseMessage>();
+            response.StatusCode = HttpStatusCode.OK;
+            response.Content = new StringContent(TriggerResultHelper.TRIGGER_RESPONSE_WITH_CHANNEL_ATTRIBUTES);
+
+            var triggerResult = new TriggerResult(response, TriggerResultHelper.TRIGGER_RESPONSE_WITH_CHANNEL_ATTRIBUTES);
+
+            Assert.AreEqual(2, triggerResult.ChannelAttributes["any-channel"].subscription_count);
+            Assert.AreEqual(1, triggerResult.ChannelAttributes["any-channel"].user_count);
+            Assert.AreEqual(1, triggerResult.EventIds.Count);
         }
     }
 }

--- a/PusherServer/ChannelAttributes.cs
+++ b/PusherServer/ChannelAttributes.cs
@@ -1,0 +1,18 @@
+namespace PusherServer
+{
+    /// <summary>
+    /// Channel attributes as returned in the trigger event endpoint
+    /// </summary>
+    public class ChannelAttributes
+    {
+        /// <summary>
+        /// Number of distinct users currently subscribed to each channel (a single user may be subscribed many times, but will only count as one)
+        /// </summary>
+        public int user_count { get; set; }
+        
+        /// <summary>
+        /// Number of connections currently subscribed to each channel. This attribute is not available by default. To enable it, navigate to your Channels dashboard, find the app you are working on, and click App Settings.
+        /// </summary>
+        public int subscription_count { get; set; }
+    }
+}

--- a/PusherServer/EventIdData.cs
+++ b/PusherServer/EventIdData.cs
@@ -9,6 +9,7 @@ namespace PusherServer
     public class EventIdData
     {
         private readonly Dictionary<string, string> _eventIds = new Dictionary<string, string>();
+        private readonly Dictionary<string, ChannelAttributes> _channelStates = new Dictionary<string, ChannelAttributes>();
 
         /// <summary>
         /// Dictionary of channel name to event ID for the triggered event.
@@ -20,5 +21,10 @@ namespace PusherServer
                 return _eventIds;
             }
         }
+
+        /// <summary>
+        /// Dictionary of channel name to channel attributes
+        /// </summary>
+        public Dictionary<string, ChannelAttributes> channels => _channelStates;
     }
 }

--- a/PusherServer/ITriggerOptions.cs
+++ b/PusherServer/ITriggerOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace PusherServer
+﻿using System.Collections.Generic;
+
+namespace PusherServer
 {
     /// <summary>
     /// Additional options that can be used when triggering an event.
@@ -9,5 +11,10 @@
         /// Gets or sets the Socket ID for a consuming Trigger
         /// </summary>
         string SocketId { get; set; }
+
+        /// <summary>
+        /// List of attributes that should be returned for each unique channel triggered to.
+        /// </summary>
+        List<string> Info { get; set; }
     }
 }

--- a/PusherServer/ITriggerResult.cs
+++ b/PusherServer/ITriggerResult.cs
@@ -11,5 +11,10 @@ namespace PusherServer
         /// Gets the Event IDs related to this Trigger Event
         /// </summary>
         IDictionary<string, string> EventIds { get; }
+
+        /// <summary>
+        /// If requested via trigger options, returns channel attributes for each channel in Trigger Event request
+        /// </summary>
+        IDictionary<string, ChannelAttributes> ChannelAttributes { get; }
     }
 }

--- a/PusherServer/Pusher.cs
+++ b/PusherServer/Pusher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using PusherServer.RestfulClient;
@@ -159,6 +160,11 @@ namespace PusherServer
             if (string.IsNullOrEmpty(options.SocketId) == false)
             {
                 bodyData.socket_id = options.SocketId;
+            }
+
+            if (options.Info != null && options.Info.Count > 0)
+            {
+                bodyData.info = string.Join(",", options.Info);
             }
 
             return bodyData;

--- a/PusherServer/TriggerBody.cs
+++ b/PusherServer/TriggerBody.cs
@@ -1,4 +1,6 @@
-﻿namespace PusherServer
+﻿using System.Collections.Generic;
+
+namespace PusherServer
 {
     /// <summary>
     /// Represents the payload to be sent when triggering events
@@ -24,5 +26,10 @@
         /// The id of a socket to be excluded from receiving the event.
         /// </summary>
         public string socket_id { get; set; }
+
+        /// <summary>
+        /// A comma-separated list of attributes that should be returned for each unique channel triggered to.
+        /// </summary>
+        public string info { get; set; }
     }
 }

--- a/PusherServer/TriggerOptions.cs
+++ b/PusherServer/TriggerOptions.cs
@@ -1,4 +1,6 @@
 ﻿
+using System.Collections.Generic;
+
 namespace PusherServer
 {
     /// <summary>
@@ -10,5 +12,10 @@ namespace PusherServer
         /// Gets or sets the Socket ID for the consuming Trigger
         /// </summary>
         public string SocketId { get; set; }
+
+        /// <summary>
+        /// List of attributes that should be returned for each unique channel triggered to.
+        /// </summary>
+        public List<string> Info { get; set; }
     }
 }

--- a/PusherServer/TriggerResult.cs
+++ b/PusherServer/TriggerResult.cs
@@ -32,9 +32,11 @@ namespace PusherServer
             }
 
             EventIds = new ReadOnlyDictionary<string, string>(eventIdData.event_ids);
+            ChannelAttributes = new ReadOnlyDictionary<string, ChannelAttributes>(eventIdData.channels);
         }
 
         /// <inheritDoc/>
         public IDictionary<string, string> EventIds { get; }
+        public IDictionary<string, ChannelAttributes> ChannelAttributes { get; }
     }
 }

--- a/Root.Build.props
+++ b/Root.Build.props
@@ -12,9 +12,9 @@
     <PackageTags>pusher channels realtime websocket</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>icon-128.png</PackageIcon>
-    <Version>4.7.0-beta.2</Version>
-    <AssemblyVersion>4.7.0.0</AssemblyVersion>
-    <FileVersion>4.7.0.0</FileVersion>
+    <Version>5.0.0</Version>
+    <AssemblyVersion>5.0.0.0</AssemblyVersion>
+    <FileVersion>5.0.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Coming from #92 

## Description

[Pusher's API](https://pusher.com/docs/channels/library_auth_reference/rest-api/#post-event-trigger-an-event) has documented an `info` parameter which allows return user or subscription counts when publishing events. This adds support for sending the info parameter and receiving channel's attributes back.

## CHANGELOG

* [ADDED] Add support for channel attributes when triggering events
